### PR TITLE
Add Qemu Guest Agent channel

### DIFF
--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -1208,10 +1208,16 @@ public class LibvirtVmDef {
       if (path == null) {
         path = "/var/lib/libvirt/qemu";
       }
+      // Used by patchviasocket.pl
       virtioSerialBuilder.append("<channel type='unix'>\n");
       virtioSerialBuilder.append("<source mode='bind' path='" + path + "/" + name + ".agent'/>\n");
       virtioSerialBuilder.append("<target type='virtio' name='" + name + ".vport'/>\n");
       virtioSerialBuilder.append("<address type='virtio-serial'/>\n");
+      virtioSerialBuilder.append("</channel>\n");
+      // Qemu guest agent
+      virtioSerialBuilder.append("<channel type='unix'>\n");
+      virtioSerialBuilder.append("<source mode='bind'/>\n");
+      virtioSerialBuilder.append("<target type='virtio' name='org.qemu.guest_agent.0'/>\n");
       virtioSerialBuilder.append("</channel>\n");
       return virtioSerialBuilder.toString();
     }


### PR DESCRIPTION
This adds a `qemu guest_agent` channel to all KVM VMs. This channel allows to communicate with guests, but only when guests have the `qemu guest agent` installed. On new systemvm templates, this is installed so we can communicate with all system VMs.

Added XML example:

```
    <channel type='unix'>
      <source mode='bind' path='/var/lib/libvirt/qemu/s-1-VM.agent'/>
      <target type='virtio' name='s-1-VM.vport' state='disconnected'/>
      <alias name='channel0'/>
      <address type='virtio-serial' controller='0' bus='0' port='1'/>
    </channel>
    <channel type='unix'>
      <source mode='bind' path='/var/lib/libvirt/qemu/channel/target/domain-s-1-VM/org.qemu.guest_agent.0'/>
      <target type='virtio' name='org.qemu.guest_agent.0' state='connected'/>
      <alias name='channel1'/>
      <address type='virtio-serial' controller='0' bus='0' port='2'/>
    </channel>
```

The original channel for `patchviasocket` is also still there.

Example cal:

```
[root@kvm2 ~]# virsh qemu-agent-command s-1-VM '{"execute":"guest-network-get-interfaces"}'
{"return":[{"name":"lo","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"127.0.0.1","prefix":8}],"hardware-address":"00:00:00:00:00:00"},{"name":"eth0","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"169.254.2.149","prefix":16}],"hardware-address":"0e:00:a9:fe:02:95"},{"name":"eth1","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"192.168.22.134","prefix":24}],"hardware-address":"06:61:aa:00:00:05"},{"name":"eth2","ip-addresses":[{"ip-address-type":"ipv4","ip-address":"192.168.23.2","prefix":24}],"hardware-address":"06:8b:34:00:00:16"}]}
```
