### PR TITLE
Fix correct number of sockets reported

### DIFF
--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -2540,7 +2540,14 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
       final NodeInfo hosts = conn.nodeInfo();
       speed = getCpuSpeed(hosts);
 
+      /*
+       * Some CPUs report a single socket and multiple NUMA cells.
+       * We need to multiply them to get the correct socket count.
+       */
       cpuSockets = hosts.sockets;
+      if (hosts.nodes > 0) {
+        cpuSockets = hosts.sockets * hosts.nodes;
+      }
       cpus = hosts.cpus;
       ram = hosts.memory * 1024L;
       final LibvirtCapXmlParser parser = new LibvirtCapXmlParser();


### PR DESCRIPTION
Seen on our prod hardware:

```
[root@kvm7452 ~]# virsh nodeinfo
CPU model:           x86_64
CPU(s):              48
CPU frequency:       2600 MHz
CPU socket(s):       1
Core(s) per socket:  12
Thread(s) per core:  2
NUMA cell(s):        2
Memory size:         528071556 KiB
```

Sockets is not 1, but needs to be multiplied by number of NUMA cells.

There really are two:

```
[root@kvm7452 ~]# cat /proc/cpuinfo | grep phys | sort -u
address sizes   : 46 bits physical, 48 bits virtual
physical id     : 0
physical id     : 1
```

Report is now OK:
![screen shot 2016-04-16 at 11 37 46](https://cloud.githubusercontent.com/assets/1630096/14580236/c0bd67c6-03c7-11e6-8ba6-844800085ae0.png)
