### PR TITLE
Set smbios info to Cosmic

### DIFF
--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -95,8 +95,8 @@ public class LibvirtVmDef {
 
         guestDef.append("<sysinfo type='smbios'>\n");
         guestDef.append("<system>\n");
-        guestDef.append("<entry name='manufacturer'>Apache Software Foundation</entry>\n");
-        guestDef.append("<entry name='product'>CloudStack " + type.toString() + " Hypervisor</entry>\n");
+        guestDef.append("<entry name='manufacturer'>Mission Critical Cloud</entry>\n");
+        guestDef.append("<entry name='product'>Cosmic " + type.toString() + " Hypervisor</entry>\n");
         guestDef.append("<entry name='uuid'>" + uuid + "</entry>\n");
         guestDef.append("</system>\n");
         guestDef.append("</sysinfo>\n");


### PR DESCRIPTION
This way KVM guests can know they run inside Cosmic by running `dmidecode`.

![demidecode](https://cloud.githubusercontent.com/assets/1630096/14583242/0a307ce6-041c-11e6-9176-e831fcc5fc09.png)

By the way, the UUID matches the one from within Cosmic so we can always trace it:
![uuid-dmidecode](https://cloud.githubusercontent.com/assets/1630096/14583251/6aa3711e-041c-11e6-8810-cf5cd4f9d1dc.png)
