### PR TITLE
Qemu GuestAgent channel for all vms

### DIFF
--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResource.java
@@ -67,13 +67,13 @@ import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DeviceType;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef.DiskProtocol;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.FeaturesDef;
-import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.FilesystemDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.GraphicDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.GuestDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.GuestResourceDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.InputDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.InterfaceDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.InterfaceDef.GuestNetType;
+import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.QemuGuestAgentDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.SerialDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.TermPolicy;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.VideoDef;
@@ -1932,6 +1932,9 @@ public class LibvirtComputingResource extends ServerResourceBase implements Serv
       final VirtioSerialDef vserial = new VirtioSerialDef(vmTo.getName(), null);
       devices.addDevice(vserial);
     }
+
+    final QemuGuestAgentDef guestagent = new QemuGuestAgentDef();
+    devices.addDevice(guestagent);
 
     final VideoDef videoCard = new VideoDef(videoHw, videoRam);
     devices.addDevice(videoCard);

--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -1214,12 +1214,20 @@ public class LibvirtVmDef {
       virtioSerialBuilder.append("<target type='virtio' name='" + name + ".vport'/>\n");
       virtioSerialBuilder.append("<address type='virtio-serial'/>\n");
       virtioSerialBuilder.append("</channel>\n");
-      // Qemu guest agent
-      virtioSerialBuilder.append("<channel type='unix'>\n");
-      virtioSerialBuilder.append("<source mode='bind'/>\n");
-      virtioSerialBuilder.append("<target type='virtio' name='org.qemu.guest_agent.0'/>\n");
-      virtioSerialBuilder.append("</channel>\n");
       return virtioSerialBuilder.toString();
+    }
+  }
+
+  public static class QemuGuestAgentDef {
+    @Override
+    public String toString() {
+      final StringBuilder qemuGuestAgentBuilder = new StringBuilder();
+
+      qemuGuestAgentBuilder.append("<channel type='unix'>\n");
+      qemuGuestAgentBuilder.append("<source mode='bind'/>\n");
+      qemuGuestAgentBuilder.append("<target type='virtio' name='org.qemu.guest_agent.0'/>\n");
+      qemuGuestAgentBuilder.append("</channel>\n");
+      return qemuGuestAgentBuilder.toString();
     }
   }
 


### PR DESCRIPTION
Only does something when one runs the daemon in the vm so won't harm.

Systemvms had it already, and still have it (and the serial one for patchviasocket):
Systemvm has them both:
![systemvm-channels](https://cloud.githubusercontent.com/assets/1630096/14753804/ee798f04-08d7-11e6-8252-d7bf1ab739a1.png)

Router also has them both:
![router-channels](https://cloud.githubusercontent.com/assets/1630096/14753816/f6e85d0a-08d7-11e6-9122-df51d9c5b078.png)

A user VM only has emu guest agent channel (previously had none):
![vm-channels](https://cloud.githubusercontent.com/assets/1630096/14753837/1566f0fc-08d8-11e6-85f8-41766b94937e.png)

When we add the Qemu Guest Agent software to the templates (Linux and Windows) we can get things like interface config from the vm, but also freeze it when snapshotting, etc. This is the base for that to be added later.
