### PR TITLE
Add RNG and Watchdog Timer devices to VMs running on KVM

### DIFF
--- a/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
+++ b/src/main/java/com/cloud/hypervisor/kvm/resource/LibvirtVmDef.java
@@ -1360,6 +1360,144 @@ public class LibvirtVmDef {
     }
   }
 
+  public static class RngDef {
+    enum RngModel {
+      VIRTIO("virtio");
+      String model;
+
+      RngModel(String model) {
+        this.model = model;
+      }
+
+      @Override
+      public String toString() {
+        return model;
+      }
+    }
+
+    enum RngBackendModel {
+      RANDOM("random"), EGD("egd");
+      String model;
+
+      RngBackendModel(String model) {
+        this.model = model;
+      }
+
+      @Override
+      public String toString() {
+        return model;
+      }
+    }
+
+    private String path = "/dev/random";
+    private RngModel rngModel = RngModel.VIRTIO;
+    private RngBackendModel rngBackendModel = RngBackendModel.RANDOM;
+
+    public RngDef(String path) {
+      this.path = path;
+    }
+
+    public RngDef(RngModel rngModel) {
+      this.rngModel = rngModel;
+    }
+
+    public RngDef(RngBackendModel rngBackendModel) {
+      this.rngBackendModel = rngBackendModel;
+    }
+
+    public RngDef(String path, RngBackendModel rngBackendModel) {
+      this.path = path;
+      this.rngBackendModel = rngBackendModel;
+    }
+
+    public RngDef(String path, RngModel rngModel) {
+      this.path = path;
+      this.rngModel = rngModel;
+    }
+
+    public String getPath() {
+      return path;
+    }
+
+    public RngBackendModel getRngBackendModel() {
+      return rngBackendModel;
+    }
+
+    public RngModel getRngModel() {
+      return rngModel;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder rngBuilder = new StringBuilder();
+      rngBuilder.append("<rng model='" + rngModel + "'>\n");
+      rngBuilder.append("<backend model='" + rngBackendModel + "'>" + path + "</backend>");
+      rngBuilder.append("</rng>\n");
+      return rngBuilder.toString();
+    }
+  }
+
+  public static class WatchDogDef {
+    enum WatchDogModel {
+      I6300ESB("i6300esb"), IB700("ib700"), DIAG288("diag288");
+      String model;
+
+      WatchDogModel(String model) {
+        this.model = model;
+      }
+
+      @Override
+      public String toString() {
+        return model;
+      }
+    }
+
+    enum WatchDogAction {
+      RESET("reset"), SHUTDOWN("shutdown"), POWEROFF("poweroff"), PAUSE("pause"), NONE("none"), DUMP("dump");
+      String action;
+
+      WatchDogAction(String action) {
+        this.action = action;
+      }
+
+      @Override
+      public String toString() {
+        return action;
+      }
+    }
+
+    WatchDogModel model = WatchDogModel.I6300ESB;
+    WatchDogAction action = WatchDogAction.NONE;
+
+    public WatchDogDef(WatchDogAction action) {
+      this.action = action;
+    }
+
+    public WatchDogDef(WatchDogModel model) {
+      this.model = model;
+    }
+
+    public WatchDogDef(WatchDogAction action, WatchDogModel model) {
+      this.action = action;
+      this.model = model;
+    }
+
+    public WatchDogAction getAction() {
+      return action;
+    }
+
+    public WatchDogModel getModel() {
+      return model;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder wacthDogBuilder = new StringBuilder();
+      wacthDogBuilder.append("<watchdog model='" + model + "' action='" + action + "'/>\n");
+      return wacthDogBuilder.toString();
+    }
+  }
+
   public void setHvsType(String hvs) {
     hvsType = hvs;
   }

--- a/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
+++ b/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtComputingResourceTest.java
@@ -318,6 +318,9 @@ public class LibvirtComputingResourceTest {
     assertXpath(domainDoc, "/domain/on_reboot/text()", "restart");
     assertXpath(domainDoc, "/domain/on_poweroff/text()", "destroy");
     assertXpath(domainDoc, "/domain/on_crash/text()", "destroy");
+
+    assertXpath(domainDoc, "/domain/devices/watchdog/@model", "i6300esb");
+    assertXpath(domainDoc, "/domain/devices/watchdog/@action", "none");
   }
 
   static Document parse(final String input) {

--- a/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
+++ b/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtDomainXMLParserTest.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.DiskDef;
 import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.InterfaceDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.RngDef;
+import com.cloud.hypervisor.kvm.resource.LibvirtVmDef.WatchDogDef;
 
 import junit.framework.TestCase;
 
@@ -149,6 +151,11 @@ public class LibvirtDomainXMLParserTest extends TestCase {
         "<alias name='balloon0'/>" +
         "<address type='pci' domain='0x0000' bus='0x00' slot='0x09' function='0x0'/>" +
         "</memballoon>" +
+        "<rng model='virtio'>" +
+        "<backend model='random'>/dev/random</backend>" +
+        "</rng>" +
+        "<watchdog model='i6300esb' action='reset'/>" +
+        "<watchdog model='ib700' action='poweroff'/>" +
         "</devices>" +
         "<seclabel type='none'/>" +
         "</domain>";
@@ -175,5 +182,15 @@ public class LibvirtDomainXMLParserTest extends TestCase {
       assertEquals(ifModel, ifs.get(i).getModel());
       assertEquals(ifType, ifs.get(i).getNetType());
     }
+
+    List<RngDef> rngs = parser.getRngs();
+    assertEquals("/dev/random", rngs.get(0).getPath());
+    assertEquals(RngDef.RngBackendModel.RANDOM, rngs.get(0).getRngBackendModel());
+
+    List<WatchDogDef> watchDogs = parser.getWatchDogs();
+    assertEquals(WatchDogDef.WatchDogModel.I6300ESB, watchDogs.get(0).getModel());
+    assertEquals(WatchDogDef.WatchDogAction.RESET, watchDogs.get(0).getAction());
+    assertEquals(WatchDogDef.WatchDogModel.IB700, watchDogs.get(1).getModel());
+    assertEquals(WatchDogDef.WatchDogAction.POWEROFF, watchDogs.get(1).getAction());
   }
 }

--- a/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
+++ b/src/test/java/com/cloud/hypervisor/kvm/resource/LibvirtVMDefTest.java
@@ -104,4 +104,27 @@ public class LibvirtVMDefTest extends TestCase {
     assertTrue((hostOsVersion.first() == 6 && hostOsVersion.second() >= 5) || (hostOsVersion.first() >= 7));
   }
 
+  public void testChannelDef() {
+    LibvirtVmDef.RngDef.RngBackendModel backendModel = LibvirtVmDef.RngDef.RngBackendModel.RANDOM;
+    String path = "/dev/random";
+
+    LibvirtVmDef.RngDef def = new LibvirtVmDef.RngDef(path, backendModel);
+    assertEquals(def.getPath(), path);
+    assertEquals(def.getRngBackendModel(), backendModel);
+    assertEquals(def.getRngModel(), LibvirtVmDef.RngDef.RngModel.VIRTIO);
+  }
+
+  public void testWatchDogDef() {
+    LibvirtVmDef.WatchDogDef def = null;
+
+    def = new LibvirtVmDef.WatchDogDef(LibvirtVmDef.WatchDogDef.WatchDogAction.RESET,
+            LibvirtVmDef.WatchDogDef.WatchDogModel.I6300ESB);
+    assertEquals(def.getAction(), LibvirtVmDef.WatchDogDef.WatchDogAction.RESET);
+    assertEquals(def.getModel(), LibvirtVmDef.WatchDogDef.WatchDogModel.I6300ESB);
+
+    def = new LibvirtVmDef.WatchDogDef(LibvirtVmDef.WatchDogDef.WatchDogAction.POWEROFF,
+            LibvirtVmDef.WatchDogDef.WatchDogModel.DIAG288);
+    assertEquals(def.getAction(), LibvirtVmDef.WatchDogDef.WatchDogAction.POWEROFF);
+    assertEquals(def.getModel(), LibvirtVmDef.WatchDogDef.WatchDogModel.DIAG288);
+  }
 }


### PR DESCRIPTION
This adds RNG (random number generator) and Watchdog timer features to KVM VMs. Without altering `agent.properties` setting no behaviour is changed.

To turn on RNG, the `agent.properties` needs to have:

```
vm.rng.enable=true
# This enabled the VirtIO Random Number Generator device for guests.
#
vm.rng.model=random
# The model of VirtIO Random Number Generator (RNG) to present to the Guest.
# Currently only 'random' is supported.
#
vm.rng.path=/dev/random
# Local Random Number Device Generator to use for VirtIO RNG for Guests.
# This is usually /dev/random, but per platform this might be different
```

Before enabling this, we need to think if it's wise to have all VMs use the `/dev/random` of the hypervisor, but we at least have the option to enable it should we want to.

The Watchdog timer is on by default, but it's up to the guest VM to start sending heartbeats. Next to that, the default action is `None` and that should be changed to `reset` to do something meaningful in case a VM stops sending heartbeats.

Settings in `agent.properties` related to the Watchdog timer:

```
vm.watchdog.model=i6300esb
# The model of Watchdog timer to present to the Guest
# For all models refer to the libvirt documentation.
# Recommend value is: i6300esb
#
vm.watchdog.action=reset
# Action to take when the Guest/Instance is no longer notifiying the Watchdog
# timer.
# For all actions refer to the libvirt documentation.
# Recommended values are: none, reset and poweroff.
```

Backport from ACS
Author: Wido den Hollander
